### PR TITLE
fix: fix selected date style

### DIFF
--- a/dev/src/ion2-calendar/components/month.component.scss
+++ b/dev/src/ion2-calendar/components/month.component.scss
@@ -192,6 +192,10 @@ $disabled-color: rgba(0, 0, 0, 0.25);
       @include transition-timing-function(ease-out);
     }
   }
+
+  .startSelection.endSelection::before {
+    --ion-color-primary: transparent;
+  }
 }
 
 :host {

--- a/src/components/month.component.scss
+++ b/src/components/month.component.scss
@@ -166,6 +166,8 @@
     -ms-transition-timing-function: ease-out;
     -o-transition-timing-function: ease-out;
     transition-timing-function: ease-out; }
+  :host .primary .startSelection.endSelection::before {
+    --ion-color-primary: transparent; }
   :host .secondary button.days-btn small,
   :host .secondary .days .marked p,
   :host .secondary .days .today p {
@@ -283,6 +285,8 @@
     -ms-transition-timing-function: ease-out;
     -o-transition-timing-function: ease-out;
     transition-timing-function: ease-out; }
+  :host .secondary .startSelection.endSelection::before {
+    --ion-color-primary: transparent; }
   :host .danger button.days-btn small,
   :host .danger .days .marked p,
   :host .danger .days .today p {
@@ -400,6 +404,8 @@
     -ms-transition-timing-function: ease-out;
     -o-transition-timing-function: ease-out;
     transition-timing-function: ease-out; }
+  :host .danger .startSelection.endSelection::before {
+    --ion-color-primary: transparent; }
   :host .dark button.days-btn small,
   :host .dark .days .marked p,
   :host .dark .days .today p {
@@ -517,6 +523,8 @@
     -ms-transition-timing-function: ease-out;
     -o-transition-timing-function: ease-out;
     transition-timing-function: ease-out; }
+  :host .dark .startSelection.endSelection::before {
+    --ion-color-primary: transparent; }
   :host .light button.days-btn small,
   :host .light .days .marked p,
   :host .light .days .today p {
@@ -634,6 +642,8 @@
     -ms-transition-timing-function: ease-out;
     -o-transition-timing-function: ease-out;
     transition-timing-function: ease-out; }
+  :host .light .startSelection.endSelection::before {
+    --ion-color-primary: transparent; }
   :host .light .days .today p {
     color: #565656; }
   :host .cal-color .days .today p {
@@ -743,3 +753,5 @@
     -ms-transition-timing-function: ease-out;
     -o-transition-timing-function: ease-out;
     transition-timing-function: ease-out; }
+  :host .cal-color .startSelection.endSelection::before {
+    --ion-color-primary: transparent; }

--- a/src/index.scss
+++ b/src/index.scss
@@ -166,6 +166,8 @@
     -ms-transition-timing-function: ease-out;
     -o-transition-timing-function: ease-out;
     transition-timing-function: ease-out; }
+  :host .primary .startSelection.endSelection::before {
+    --ion-color-primary: transparent; }
   :host .secondary button.days-btn small,
   :host .secondary .days .marked p,
   :host .secondary .days .today p {
@@ -283,6 +285,8 @@
     -ms-transition-timing-function: ease-out;
     -o-transition-timing-function: ease-out;
     transition-timing-function: ease-out; }
+  :host .secondary .startSelection.endSelection::before {
+    --ion-color-primary: transparent; }
   :host .danger button.days-btn small,
   :host .danger .days .marked p,
   :host .danger .days .today p {
@@ -400,6 +404,8 @@
     -ms-transition-timing-function: ease-out;
     -o-transition-timing-function: ease-out;
     transition-timing-function: ease-out; }
+  :host .danger .startSelection.endSelection::before {
+    --ion-color-primary: transparent; }
   :host .dark button.days-btn small,
   :host .dark .days .marked p,
   :host .dark .days .today p {
@@ -517,6 +523,8 @@
     -ms-transition-timing-function: ease-out;
     -o-transition-timing-function: ease-out;
     transition-timing-function: ease-out; }
+  :host .dark .startSelection.endSelection::before {
+    --ion-color-primary: transparent; }
   :host .light button.days-btn small,
   :host .light .days .marked p,
   :host .light .days .today p {
@@ -634,6 +642,8 @@
     -ms-transition-timing-function: ease-out;
     -o-transition-timing-function: ease-out;
     transition-timing-function: ease-out; }
+  :host .light .startSelection.endSelection::before {
+    --ion-color-primary: transparent; }
   :host .light .days .today p {
     color: #565656; }
   :host .cal-color .days .today p {
@@ -743,6 +753,8 @@
     -ms-transition-timing-function: ease-out;
     -o-transition-timing-function: ease-out;
     transition-timing-function: ease-out; }
+  :host .cal-color .startSelection.endSelection::before {
+    --ion-color-primary: transparent; }
 
 :host .month-picker {
   margin: 20px 0;


### PR DESCRIPTION
… date for range selection


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Demos changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently when using range selection on the calendar. If you chose the same start and end date then the date selected has a abnormal styling.

Here is an example of what is currently looks like:
![calendar-broke](https://user-images.githubusercontent.com/22036883/53816524-b094cd00-3f31-11e9-9d99-c3a502344983.png)

## What is the new behavior?
With this change the selected date is now styled as a circle as expected.

Here is an example of what is looks like with this change:
![calendar-fixed](https://user-images.githubusercontent.com/22036883/53816615-d3bf7c80-3f31-11e9-8113-2db438732cec.png)



## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```