### PR TITLE
Improved Date Range UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,31 +413,32 @@ openCalendar() {
 
 ### Modal Options
 
-| Name                 | Type                     | Default                               | Description                                                |
-| -------------------- | ------------------------ | ------------------------------------- | ---------------------------------------------------------- |
-| from                 | Date                     | `new Date()`                          | start date                                                 |
-| to                   | Date                     | 0 (Infinite)                          | end date                                                   |
-| title                | string                   | `'CALENDAR'`                          | title                                                      |
-| color                | string                   | `'primary'`                           | 'primary', 'secondary', 'danger', 'light', 'dark'          |
-| defaultScrollTo      | Date                     | none                                  | let the view scroll to the default date                    |
-| defaultDate          | Date                     | none                                  | default date data, apply to single                         |
-| defaultDates         | Array<Date>              | none                                  | default dates data, apply to multi                         |
-| defaultDateRange     | { from: Date, to: Date } | none                                  | default date-range data, apply to range                    |
-| defaultTitle         | string                   | ''                                    | default title in days                                      |
-| defaultSubtitle      | string                   | ''                                    | default subtitle in days                                   |
-| cssClass             | string                   | `''`                                  | Additional classes for custom styles, separated by spaces. |
-| canBackwardsSelected | boolean                  | `false`                               | can backwards selected                                     |
-| pickMode             | string                   | `single`                              | 'multi', 'range', 'single'                                 |
-| disableWeeks         | Array<number>            | `[]`                                  | week to be disabled (0-6)                                  |
-| closeLabel           | string                   | `CANCEL`                              | cancel button label                                        |
-| doneLabel            | string                   | `DONE`                                | done button label                                          |
-| closeIcon            | boolean                  | `false`                               | show cancel button icon                                    |
-| doneIcon             | boolean                  | `false`                               | show done button icon                                      |
-| monthFormat          | string                   | `'MMM YYYY'`                          | month title format                                         |
-| weekdays             | Array<string>            | `['S', 'M', 'T', 'W', 'T', 'F', 'S']` | weeks text                                                 |
-| weekStart            | number                   | `0` (0 or 1)                          | set week start day                                         |
-| daysConfig           | Array<**_DaysConfig_**>  | `[]`                                  | days configuration                                         |
-| step                 | number                   | `12`                                  | month load stepping interval to when scroll                |
+| Name                      | Type                     | Default                               | Description                                                |
+| ------------------------- | ------------------------ | ------------------------------------- | ---------------------------------------------------------- |
+| from                      | Date                     | `new Date()`                          | start date                                                 |
+| to                        | Date                     | 0 (Infinite)                          | end date                                                   |
+| title                     | string                   | `'CALENDAR'`                          | title                                                      |
+| color                     | string                   | `'primary'`                           | 'primary', 'secondary', 'danger', 'light', 'dark'          |
+| defaultScrollTo           | Date                     | none                                  | let the view scroll to the default date                    |
+| defaultDate               | Date                     | none                                  | default date data, apply to single                         |
+| defaultDates              | Array<Date>              | none                                  | default dates data, apply to multi                         |
+| defaultDateRange          | { from: Date, to: Date } | none                                  | default date-range data, apply to range                    |
+| defaultTitle              | string                   | ''                                    | default title in days                                      |
+| defaultSubtitle           | string                   | ''                                    | default subtitle in days                                   |
+| cssClass                  | string                   | `''`                                  | Additional classes for custom styles, separated by spaces. |
+| canBackwardsSelected      | boolean                  | `false`                               | can backwards selected                                     |
+| pickMode                  | string                   | `single`                              | 'multi', 'range', 'single'                                 |
+| disableWeeks              | Array<number>            | `[]`                                  | week to be disabled (0-6)                                  |
+| closeLabel                | string                   | `CANCEL`                              | cancel button label                                        |
+| doneLabel                 | string                   | `DONE`                                | done button label                                          |
+| closeIcon                 | boolean                  | `false`                               | show cancel button icon                                    |
+| doneIcon                  | boolean                  | `false`                               | show done button icon                                      |
+| monthFormat               | string                   | `'MMM YYYY'`                          | month title format                                         |
+| weekdays                  | Array<string>            | `['S', 'M', 'T', 'W', 'T', 'F', 'S']` | weeks text                                                 |
+| weekStart                 | number                   | `0` (0 or 1)                          | set week start day                                         |
+| daysConfig                | Array<**_DaysConfig_**>  | `[]`                                  | days configuration                                         |
+| step                      | number                   | `12`                                  | month load stepping interval to when scroll                |
+| defaultEndDateToStartDate | boolean                  | `false`                               | makes the end date optional, will default it to the start  |
 
 ### onDidDismiss Output `{ data } = event`
 

--- a/dev/src/app/home/home.page.html
+++ b/dev/src/app/home/home.page.html
@@ -18,6 +18,7 @@
   <demo-modal-custom-style></demo-modal-custom-style>
   <demo-modal-default-scroll></demo-modal-default-scroll>
   <demo-modal-config-days></demo-modal-config-days>
+  <demo-range-with-default-end-date></demo-range-with-default-end-date>
   <h2>component mode</h2>
   <demo-basic></demo-basic>
   <demo-multi></demo-multi>

--- a/dev/src/demos/demo-modal-range-with-default-end-date.ts
+++ b/dev/src/demos/demo-modal-range-with-default-end-date.ts
@@ -1,0 +1,53 @@
+import { Component } from '@angular/core';
+import { ModalController } from '@ionic/angular';
+
+import { CalendarModal, CalendarModalOptions } from '../ion2-calendar';
+
+@Component({
+  selector: 'demo-range-with-default-end-date',
+  template: `
+    <ion-button (click)="openCalendar()">
+      end date defaulted to start date
+    </ion-button>
+  `,
+})
+export class DemoModalRangeWithDefaultEndDate {
+  dateRange: {
+    from: Date;
+  } = {
+    from: new Date(),
+  };
+
+  constructor(public modalCtrl: ModalController) {}
+
+  async openCalendar() {
+    const options: CalendarModalOptions = {
+      pickMode: 'range',
+      title: 'RANGE',
+      defaultDateRange: this.dateRange,
+      defaultEndDateToStartDate: true,
+    };
+
+    const myCalendar = await this.modalCtrl.create({
+      component: CalendarModal,
+      componentProps: { options },
+    });
+
+    myCalendar.present();
+
+    const event: any = await myCalendar.onDidDismiss();
+    const { data: date, role } = event;
+
+    if (role === 'done') {
+      this.dateRange = Object.assign(
+        {},
+        {
+          from: date.from.dateObj,
+          to: date.to.dateObj,
+        }
+      );
+    }
+    console.log(date);
+    console.log('role', role);
+  }
+}

--- a/dev/src/demos/demos.module.ts
+++ b/dev/src/demos/demos.module.ts
@@ -21,6 +21,7 @@ import { DemoMethodsComponent } from './demo-methods';
 import { DemoModalRangeBackwardsComponent } from './demo-modal-range-backwards';
 import { DemoModalCustomSubHeaderComponent } from './demo-modal-custom-sub-header';
 import { SubHeaderCalendarModal } from './sub-header-calendar-modal';
+import { DemoModalRangeWithDefaultEndDate } from './demo-modal-range-with-default-end-date';
 
 const COMPONENTS = [
   DemoModalBasicComponent,
@@ -40,6 +41,7 @@ const COMPONENTS = [
   DemoEventsComponent,
   DemoMethodsComponent,
   DemoModalRangeBackwardsComponent,
+  DemoModalRangeWithDefaultEndDate,
 ];
 
 @NgModule({

--- a/dev/src/ion2-calendar/calendar.model.ts
+++ b/dev/src/ion2-calendar/calendar.model.ts
@@ -70,6 +70,7 @@ export interface CalendarModalOptions extends CalendarOptions {
    * @deprecated this version notwork
    */
   showYearPicker?: boolean;
+  defaultEndDateToStartDate?: boolean;
 }
 
 export interface CalendarOptions {

--- a/dev/src/ion2-calendar/components/calendar.modal.ts
+++ b/dev/src/ion2-calendar/components/calendar.modal.ts
@@ -198,12 +198,15 @@ export class CalendarModal implements OnInit, AfterViewInit {
     if (!Array.isArray(this.datesTemp)) {
       return false;
     }
-    const { pickMode } = this._d;
+    const { pickMode, defaultEndDateToStartDate } = this._d;
 
     switch (pickMode) {
       case pickModes.SINGLE:
         return !!(this.datesTemp[0] && this.datesTemp[0].time);
       case pickModes.RANGE:
+        if (defaultEndDateToStartDate) {
+          return !!(this.datesTemp[0] && this.datesTemp[0].time);
+        }
         return !!(this.datesTemp[0] && this.datesTemp[1]) && !!(this.datesTemp[0].time && this.datesTemp[1].time);
       case pickModes.MULTI:
         return this.datesTemp.length > 0 && this.datesTemp.every(e => !!e && !!e.time);

--- a/dev/src/ion2-calendar/components/month.component.ts
+++ b/dev/src/ion2-calendar/components/month.component.ts
@@ -208,11 +208,18 @@ export class MonthComponent implements ControlValueAccessor, AfterViewInit {
           this._date[0] = item;
           this.selectStart.emit(item);
         }
+      } else if (this._date[0].time > item.time) {
+        this._date[0] = item;
+        this.selectStart.emit(item);
+      } else if (this._date[1].time < item.time) {
+        this._date[1] = item;
+        this.selectEnd.emit(item);
       } else {
         this._date[0] = item;
         this.selectStart.emit(item);
         this._date[1] = null;
       }
+
       this.change.emit(this._date);
       return;
     }

--- a/dev/src/ion2-calendar/services/calendar.service.ts
+++ b/dev/src/ion2-calendar/services/calendar.service.ts
@@ -54,6 +54,7 @@ export class CalendarService {
       daysConfig = _daysConfig,
       disableWeeks = _disableWeeks,
       showAdjacentMonthDay = true,
+      defaultEndDateToStartDate = false,
     } = { ...this.defaultOpts, ...calendarOptions };
 
     return {
@@ -84,7 +85,8 @@ export class CalendarService {
       defaultDate: calendarOptions.defaultDate || null,
       defaultDates: calendarOptions.defaultDates || null,
       defaultDateRange: calendarOptions.defaultDateRange || null,
-      showAdjacentMonthDay
+      showAdjacentMonthDay,
+      defaultEndDateToStartDate
     };
   }
 
@@ -242,7 +244,7 @@ export class CalendarService {
       case pickModes.RANGE:
         result = {
           from: this.multiFormat(original[0].time),
-          to: this.multiFormat(original[1].time),
+          to: this.multiFormat((original[1] || original[0]).time),
         };
         break;
       case pickModes.MULTI:

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@angular/common": "7.1.4",
     "@angular/compiler": "7.1.4",
-    "@angular/compiler-cli": "7.1.4",
+    "@angular/compiler-cli": "^7.2.9",
     "@angular/core": "7.1.4",
     "@angular/forms": "7.1.4",
     "@angular/http": "7.1.4",

--- a/src/calendar.model.ts
+++ b/src/calendar.model.ts
@@ -70,6 +70,7 @@ export interface CalendarModalOptions extends CalendarOptions {
    * @deprecated this version notwork
    */
   showYearPicker?: boolean;
+  defaultEndDateToStartDate?: boolean;
 }
 
 export interface CalendarOptions {

--- a/src/components/calendar.modal.ts
+++ b/src/components/calendar.modal.ts
@@ -198,12 +198,15 @@ export class CalendarModal implements OnInit, AfterViewInit {
     if (!Array.isArray(this.datesTemp)) {
       return false;
     }
-    const { pickMode } = this._d;
+    const { pickMode, defaultEndDateToStartDate } = this._d;
 
     switch (pickMode) {
       case pickModes.SINGLE:
         return !!(this.datesTemp[0] && this.datesTemp[0].time);
       case pickModes.RANGE:
+        if (defaultEndDateToStartDate) {
+          return !!(this.datesTemp[0] && this.datesTemp[0].time);
+        }
         return !!(this.datesTemp[0] && this.datesTemp[1]) && !!(this.datesTemp[0].time && this.datesTemp[1].time);
       case pickModes.MULTI:
         return this.datesTemp.length > 0 && this.datesTemp.every(e => !!e && !!e.time);

--- a/src/components/month.component.ts
+++ b/src/components/month.component.ts
@@ -208,11 +208,18 @@ export class MonthComponent implements ControlValueAccessor, AfterViewInit {
           this._date[0] = item;
           this.selectStart.emit(item);
         }
+      } else if (this._date[0].time > item.time) {
+        this._date[0] = item;
+        this.selectStart.emit(item);
+      } else if (this._date[1].time < item.time) {
+        this._date[1] = item;
+        this.selectEnd.emit(item);
       } else {
         this._date[0] = item;
         this.selectStart.emit(item);
         this._date[1] = null;
       }
+
       this.change.emit(this._date);
       return;
     }

--- a/src/services/calendar.service.ts
+++ b/src/services/calendar.service.ts
@@ -54,6 +54,7 @@ export class CalendarService {
       daysConfig = _daysConfig,
       disableWeeks = _disableWeeks,
       showAdjacentMonthDay = true,
+      defaultEndDateToStartDate = false,
     } = { ...this.defaultOpts, ...calendarOptions };
 
     return {
@@ -84,7 +85,8 @@ export class CalendarService {
       defaultDate: calendarOptions.defaultDate || null,
       defaultDates: calendarOptions.defaultDates || null,
       defaultDateRange: calendarOptions.defaultDateRange || null,
-      showAdjacentMonthDay
+      showAdjacentMonthDay,
+      defaultEndDateToStartDate
     };
   }
 
@@ -242,7 +244,7 @@ export class CalendarService {
       case pickModes.RANGE:
         result = {
           from: this.multiFormat(original[0].time),
-          to: this.multiFormat(original[1].time),
+          to: this.multiFormat((original[1] || original[0]).time),
         };
         break;
       case pickModes.MULTI:


### PR DESCRIPTION
Improved the UX related to date ranges and added an option to default the end date to the start date


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Demos changes
[ ] Other... Please describe:
```

## What is the current behavior?

There is no way to say that the end date should just default to the start date, and the UX for the way that ranges are selected was lacking.

Currently if you have a range selected, clicking any new date resets the range and sets that new date to the start date

## What is the new behavior?

Now there is an option that allows you to default the end date to the start date in the range

Additionally if you have a date range selected, clicking any date outside the range will extend the range in that direction, IE: 19-21 selected, clicking 18 will change the range to 18-21

Clicking inside the range or equal to the limits still resets the range and selects that value as the start date.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
